### PR TITLE
Prevent memory leak on every callback

### DIFF
--- a/indev/XPT7603.c
+++ b/indev/XPT7603.c
@@ -35,6 +35,7 @@ static void xpt7603_avg(int16_t * x, int16_t * y);
 int16_t avg_buf_x[XPT7603_AVG];
 int16_t avg_buf_y[XPT7603_AVG];
 uint8_t avg_last;
+unsigned long int *regAddress;
 
 /**********************
  *      MACROS
@@ -120,22 +121,23 @@ uint16_t om_i2c_read(int addr) {
 int om_read_gpio(int gpioNumber) {
     int  m_mfd;
     int regAddrOffset = GPIO_REG_DATA0_OFFSET;
-    unsigned long int *regAddress;
     unsigned long int 	value = 0x0;
     int gpioVal;
-    
-    if ((m_mfd = open("/dev/mem", O_RDWR)) < 0)
-	{
-		return EXIT_FAILURE;	// maybe return -1
-	}
-	regAddress = (unsigned long int*)mmap	(	NULL, 
-												1024, 
-												PROT_READ|PROT_WRITE, 
-												MAP_FILE|MAP_SHARED, 
-												m_mfd, 
-												GPIO_REG_BLOCK_ADDR
-											);
-    close(m_mfd);
+
+    if (regAddress == NULL){
+	    if ((m_mfd = open("/dev/mem", O_RDWR)) < 0)
+	    {
+		    return EXIT_FAILURE;	// maybe return -1
+	    }
+	    regAddress = (unsigned long int*)mmap(NULL, 
+						  1024, 
+						  PROT_READ|PROT_WRITE, 
+						  MAP_FILE|MAP_SHARED, 
+						  m_mfd, 
+						  GPIO_REG_BLOCK_ADDR
+						 );
+	    close(m_mfd);
+    }
     
 	// read the value 
 	value = *(regAddress + regAddrOffset);


### PR DESCRIPTION
This implementation works by only doing the mmap on the first invocation. I had thought about putting the mmap code inside of the xpt7603_init function. However, this function does not seem to ever get called in the normal flow using the existing example code. So this workaround is a quick and dirty fix that solves the underlying issue. 